### PR TITLE
Improve NotFound page with Material UI

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -2,7 +2,6 @@
 // Endpoint de salud para monitoreo básico y metadatos de despliegue.
 // Responde con JSON y NO se cachea, útil para checks externos.
 /* eslint-env node */
-/* global process */
 
 export default function handler(req, res) {
   const payload = {

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,10 +1,41 @@
-import { Container, Typography } from '@mui/material'
+import { Box, Button, Container, Paper, Stack, Typography } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 
 export default function NotFound() {
   return (
-    <Container>
-      <Typography variant="h1" gutterBottom>404</Typography>
-      <Typography>Página no encontrada.</Typography>
+    <Container
+      component="main"
+      sx={{
+        display: 'flex',
+        minHeight: '100vh',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Paper elevation={3} sx={{ p: 5 }}>
+        <Stack spacing={2} textAlign="center">
+          <Typography variant="h1" color="primary" gutterBottom>
+            404
+          </Typography>
+          <Typography variant="h5" gutterBottom>
+            Página no encontrada
+          </Typography>
+          <Typography>
+            Lo sentimos, la página que buscas no existe. Nuestro equipo cuida
+            cada detalle; vuelve al inicio para continuar tu experiencia.
+          </Typography>
+          <Box>
+            <Button
+              component={RouterLink}
+              to="/"
+              variant="contained"
+              color="primary"
+            >
+              Volver al inicio
+            </Button>
+          </Box>
+        </Stack>
+      </Paper>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary
- Design a friendly, professional 404 page using Material UI components and a subtle nod to the personalized aesthetic service.
- Remove redundant global declaration in the health API to clear linter errors.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a602ff461483268a93ad0f93548256