### PR TITLE
Improve SEO metadata for Montevideo aesthetic site

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -2,7 +2,6 @@
 // Endpoint de salud para monitoreo básico y metadatos de despliegue.
 // Responde con JSON y NO se cachea, útil para checks externos.
 /* eslint-env node */
-/* global process */
 
 export default function handler(req, res) {
   const payload = {

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -1,8 +1,27 @@
-export default function SEO({ title, description }) {
+export default function SEO({
+  title = 'URBANO | Estética en Montevideo',
+  description = 'Centro de estética en Montevideo, Uruguay. Tratamientos faciales, corporales y de belleza integral.',
+  keywords = 'estética, belleza, depilación, masajes, Montevideo, Uruguay, tratamientos faciales',
+  image,
+  url,
+}) {
+  const metaUrl = url || (typeof window !== 'undefined' ? window.location.href : '')
   return (
     <>
-      {title && <title>{title}</title>}
-      {description && <meta name="description" content={description} />}
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {keywords && <meta name="keywords" content={keywords} />}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="website" />
+      {metaUrl && <meta property="og:url" content={metaUrl} />}
+      {image && <meta property="og:image" content={image} />}
+      <meta property="og:locale" content="es_UY" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      {image && <meta name="twitter:image" content={image} />}
+      {metaUrl && <link rel="canonical" href={metaUrl} />}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- enhance SEO component with default title/description for an aesthetic center in Montevideo and add Open Graph, Twitter, keywords and canonical tags
- remove redundant global comment in health endpoint to satisfy linter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a605d9152c8326bc3a91785ec0aa5f