### PR TITLE
Fix missing JSX extensions in landing pages

### DIFF
--- a/src/pages/landing/CinturonAcero.jsx
+++ b/src/pages/landing/CinturonAcero.jsx
@@ -1,4 +1,4 @@
-import SEO from '../../components/SEO'
+import SEO from '../../components/SEO.jsx'
 import { Container, Typography, Box } from '@mui/material'
 
 export default function CinturonAcero() {

--- a/src/pages/landing/CinturonOrion.jsx
+++ b/src/pages/landing/CinturonOrion.jsx
@@ -1,4 +1,4 @@
-import SEO from '../../components/SEO'
+import SEO from '../../components/SEO.jsx'
 import { Container, Typography, Box } from '@mui/material'
 
 export default function CinturonOrion() {

--- a/src/pages/landing/CinturonTitan.jsx
+++ b/src/pages/landing/CinturonTitan.jsx
@@ -1,4 +1,4 @@
-import SEO from '../../components/SEO'
+import SEO from '../../components/SEO.jsx'
 import { Container, Typography, Box } from '@mui/material'
 
 export default function CinturonTitan() {

--- a/src/pages/landing/PromoSept.jsx
+++ b/src/pages/landing/PromoSept.jsx
@@ -1,4 +1,4 @@
-import SEO from '../../components/SEO'
+import SEO from '../../components/SEO.jsx'
 import { Link as RouterLink } from 'react-router-dom'
 import {
   Container,


### PR DESCRIPTION
## Summary
- Fix SEO component imports by adding explicit `.jsx` extension across landing pages to ensure proper module resolution.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a608a10f988326b677d14699e11e79