### PR TITLE
Actualiza menú y página de oferta de apertura

### DIFF
--- a/src/layouts/LandingLayout.jsx
+++ b/src/layouts/LandingLayout.jsx
@@ -8,7 +8,7 @@ export default function LandingLayout() {
       <Box component="header" display="flex" justifyContent="space-between" alignItems="center" mb={3} gap={2}>
         <Box display="flex" alignItems="center" gap={2}>
           <Link component={RouterLink} to="/cinturon-orion" underline="none" color="inherit">
-            FORMA Urbana
+            Cinturón de Orión
           </Link>
           <Box component="nav" display="flex" gap={2}>
             <Link component={RouterLink} to="/cinturon-titan" underline="hover">
@@ -16,9 +16,6 @@ export default function LandingLayout() {
             </Link>
             <Link component={RouterLink} to="/cinturon-acero" underline="hover">
               Cinturón de Acero
-            </Link>
-            <Link component={RouterLink} to="/promo-sept" underline="hover">
-              Promo Sept
             </Link>
           </Box>
         </Box>

--- a/src/pages/_registry.js
+++ b/src/pages/_registry.js
@@ -12,7 +12,7 @@ export const LANDINGS = [
     import: () => import('./landing/CinturonAcero.jsx'),
   },
   {
-    path: '/promo-sept',
-    import: () => import('./landing/PromoSept.jsx'),
+    path: '/oferta-apertura',
+    import: () => import('./landing/OfertaApertura.jsx'),
   },
 ]

--- a/src/pages/landing/OfertaApertura.jsx
+++ b/src/pages/landing/OfertaApertura.jsx
@@ -82,10 +82,10 @@ function ProgramCard({ program }) {
   )
 }
 
-export default function PromoSept() {
+export default function OfertaApertura() {
   return (
     <>
-      <SEO title="FORMA Urbana — Programas Cinturón" description="Información de los tres programas Cinturón." />
+      <SEO title="FORMA Urbana — Oferta de Apertura" description="Información de los tres programas Cinturón." />
       <Container sx={{ my: 4 }}>
         <Typography variant="h1" gutterBottom>
           Programas Cinturón


### PR DESCRIPTION
## Summary
- Renombra el enlace principal a "Cinturón de Orión" y elimina el acceso visible a la oferta desde el menú
- Crea la página "Oferta de Apertura" y actualiza la ruta correspondiente

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a638b4d2c88326b5bae4c87bb3abc1