### PR TITLE
Highlight active menu link

### DIFF
--- a/src/layouts/LandingLayout.jsx
+++ b/src/layouts/LandingLayout.jsx
@@ -1,23 +1,35 @@
-import { Link as RouterLink, Outlet } from 'react-router-dom'
+import { Link as RouterLink, Outlet, useLocation } from 'react-router-dom'
 import StatusBadge from '../components/StatusBadge.jsx'
 import { Container, Box, Typography, Link } from '@mui/material'
 
 export default function LandingLayout() {
+  const { pathname } = useLocation()
+
+  const links = [
+    { to: '/cinturon-orion', label: 'Cinturón de Orión' },
+    { to: '/cinturon-titan', label: 'Cinturón de Titán' },
+    { to: '/cinturon-acero', label: 'Cinturón de Acero' },
+  ]
+
   return (
     <Container maxWidth="md" sx={{ py: 3 }}>
       <Box component="header" display="flex" justifyContent="space-between" alignItems="center" mb={3} gap={2}>
-        <Box display="flex" alignItems="center" gap={2}>
-          <Link component={RouterLink} to="/cinturon-orion" underline="none" color="inherit">
-            Cinturón de Orión
-          </Link>
-          <Box component="nav" display="flex" gap={2}>
-            <Link component={RouterLink} to="/cinturon-titan" underline="hover">
-              Cinturón de Titán
-            </Link>
-            <Link component={RouterLink} to="/cinturon-acero" underline="hover">
-              Cinturón de Acero
-            </Link>
-          </Box>
+        <Box component="nav" display="flex" alignItems="center" gap={2}>
+          {links.map(({ to, label }) => {
+            const isActive = pathname === to
+            return (
+              <Link
+                key={to}
+                component={isActive ? 'span' : RouterLink}
+                to={isActive ? undefined : to}
+                underline={isActive ? 'none' : 'hover'}
+                color={isActive ? 'text.primary' : 'primary.main'}
+                sx={isActive ? { pointerEvents: 'none' } : undefined}
+              >
+                {label}
+              </Link>
+            )
+          })}
         </Box>
         <StatusBadge />
       </Box>


### PR DESCRIPTION
## Summary
- Track current route in layout to render active menu link
- Active menu item is shown in black and its link disabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68a63d2aa2f48326bb07f39fa4542b8f