### PR TITLE
feat: separate layout for promotional landing

### DIFF
--- a/src/layouts/PromoLandingLayout.jsx
+++ b/src/layouts/PromoLandingLayout.jsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom'
+import { Container, Box, Typography } from '@mui/material'
+
+export default function PromoLandingLayout() {
+  return (
+    <Container maxWidth="md" sx={{ py: 3 }}>
+      <Box component="main">
+        <Outlet />
+      </Box>
+      <Typography component="footer" mt={6} fontSize={12} color="text.secondary">
+        © {new Date().getFullYear()} FORMA Urbana
+      </Typography>
+    </Container>
+  )
+}

--- a/src/router/routes.jsx
+++ b/src/router/routes.jsx
@@ -1,16 +1,22 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import LandingLayout from '../layouts/LandingLayout.jsx'
+import PromoLandingLayout from '../layouts/PromoLandingLayout.jsx'
 import NotFound from '../pages/NotFound.jsx'
 import { LANDINGS } from '../pages/_registry.js'
 import React from 'react'
 import { Box, CircularProgress } from '@mui/material'
 
 export default function AppRoutes() {
+  const promoPath = '/oferta-apertura'
+  const promoLanding = LANDINGS.find((l) => l.path === promoPath)
+  const regularLandings = LANDINGS.filter((l) => l.path !== promoPath)
+  const PromoPage = promoLanding ? React.lazy(promoLanding.import) : null
+
   return (
     <Routes>
       <Route element={<LandingLayout />}>
         <Route index element={<Navigate to="/cinturon-orion" replace />} />
-        {LANDINGS.map(({ path, import: importer }, idx) => {
+        {regularLandings.map(({ path, import: importer }, idx) => {
           const Page = React.lazy(importer)
           return (
             <Route
@@ -31,6 +37,24 @@ export default function AppRoutes() {
           )
         })}
       </Route>
+      {PromoPage && (
+        <Route element={<PromoLandingLayout />}>
+          <Route
+            path={promoLanding.path}
+            element={
+              <React.Suspense
+                fallback={
+                  <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+                    <CircularProgress />
+                  </Box>
+                }
+              >
+                <PromoPage />
+              </React.Suspense>
+            }
+          />
+        </Route>
+      )}
       <Route path="*" element={<NotFound />} />
     </Routes>
   )


### PR DESCRIPTION
## Summary
- add promo landing layout without header
- route Oferta de Apertura through promo layout to hide main navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a63db3d7608326b27d4d9f755bb732