### PR TITLE
style: center landing content and lighten background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #f5f5f5;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +23,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -54,15 +51,4 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
+

--- a/src/pages/landing/CinturonAcero.jsx
+++ b/src/pages/landing/CinturonAcero.jsx
@@ -5,7 +5,7 @@ export default function CinturonAcero() {
   return (
     <>
       <SEO title="FORMA Urbana — Cinturón de Acero" description="Diseñado para llevar tu músculo abdominal a su máximo potencial." />
-      <Container component="section" sx={{ my: 4 }}>
+      <Container component="section" sx={{ my: 4, textAlign: 'center' }}>
         <Typography variant="h1" gutterBottom>Cinturón de Acero</Typography>
         <Typography sx={{ mb: 2 }}>
           Diseñado para llevar tu músculo abdominal a su máximo potencial.

--- a/src/pages/landing/CinturonOrion.jsx
+++ b/src/pages/landing/CinturonOrion.jsx
@@ -5,7 +5,7 @@ export default function CinturonOrion() {
   return (
     <>
       <SEO title="FORMA Urbana — Cinturón de Orión" description="Reducir y tensar la piel." />
-      <Container component="section" sx={{ my: 4 }}>
+      <Container component="section" sx={{ my: 4, textAlign: 'center' }}>
         <Typography variant="h1" gutterBottom>Cinturón de Orión</Typography>
         <Typography sx={{ mb: 2 }}>Reducir y tensar la piel.</Typography>
         <Box component="ul" sx={{ mb: 2 }}>

--- a/src/pages/landing/CinturonTitan.jsx
+++ b/src/pages/landing/CinturonTitan.jsx
@@ -5,7 +5,7 @@ export default function CinturonTitan() {
   return (
     <>
       <SEO title="FORMA Urbana — Cinturón de Titán" description="Reduce y tonifica al mismo tiempo de forma eficiente." />
-      <Container component="section" sx={{ my: 4 }}>
+      <Container component="section" sx={{ my: 4, textAlign: 'center' }}>
         <Typography variant="h1" gutterBottom>Cinturón de Titán</Typography>
         <Typography sx={{ mb: 2 }}>
           Reduce y tonifica al mismo tiempo de forma eficiente.

--- a/src/pages/landing/OfertaApertura.jsx
+++ b/src/pages/landing/OfertaApertura.jsx
@@ -86,11 +86,11 @@ export default function OfertaApertura() {
   return (
     <>
       <SEO title="FORMA Urbana — Oferta de Apertura" description="Información de los tres programas Cinturón." />
-      <Container sx={{ my: 4 }}>
+      <Container sx={{ my: 4, textAlign: 'center' }}>
         <Typography variant="h1" gutterBottom>
           Programas Cinturón
         </Typography>
-        <Grid container spacing={2}>
+        <Grid container spacing={2} justifyContent="center">
           {PROGRAMS.map((program) => (
             <Grid
               key={program.name}


### PR DESCRIPTION
## Summary
- Center landing pages with `textAlign: center`
- Use a light gray background for contrast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a6516323cc8326b416f33039cce2f5