### PR TITLE
feat: mejorar landings con fondo gris y placeholders

### DIFF
--- a/public/landings/cinturon-acero/placeholder-extra.svg
+++ b/public/landings/cinturon-acero/placeholder-extra.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#9e9e9e" font-family="Arial, sans-serif" font-size="24">Imagen</text>
+</svg>

--- a/public/landings/cinturon-acero/placeholder-hero.svg
+++ b/public/landings/cinturon-acero/placeholder-hero.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
+  <rect width="100%" height="100%" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#9e9e9e" font-family="Arial, sans-serif" font-size="24">Imagen</text>
+</svg>

--- a/public/landings/cinturon-orion/placeholder-extra.svg
+++ b/public/landings/cinturon-orion/placeholder-extra.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#9e9e9e" font-family="Arial, sans-serif" font-size="24">Imagen</text>
+</svg>

--- a/public/landings/cinturon-orion/placeholder-hero.svg
+++ b/public/landings/cinturon-orion/placeholder-hero.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
+  <rect width="100%" height="100%" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#9e9e9e" font-family="Arial, sans-serif" font-size="24">Imagen</text>
+</svg>

--- a/public/landings/cinturon-titan/placeholder-extra.svg
+++ b/public/landings/cinturon-titan/placeholder-extra.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#9e9e9e" font-family="Arial, sans-serif" font-size="24">Imagen</text>
+</svg>

--- a/public/landings/cinturon-titan/placeholder-hero.svg
+++ b/public/landings/cinturon-titan/placeholder-hero.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
+  <rect width="100%" height="100%" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#9e9e9e" font-family="Arial, sans-serif" font-size="24">Imagen</text>
+</svg>

--- a/src/layouts/LandingLayout.jsx
+++ b/src/layouts/LandingLayout.jsx
@@ -12,12 +12,13 @@ export default function LandingLayout() {
   ]
 
   return (
-    <Container maxWidth="md" sx={{ py: 3 }}>
-      <Box component="header" display="flex" justifyContent="space-between" alignItems="center" mb={3} gap={2}>
-        <Box component="nav" display="flex" alignItems="center" gap={2}>
-          {links.map(({ to, label }) => {
-            const isActive = pathname === to
-            return (
+    <Box sx={{ minHeight: '100vh', bgcolor: 'grey.100' }}>
+      <Container maxWidth="md" sx={{ py: 3 }}>
+        <Box component="header" display="flex" justifyContent="space-between" alignItems="center" mb={3} gap={2}>
+          <Box component="nav" display="flex" alignItems="center" gap={2}>
+            {links.map(({ to, label }) => {
+              const isActive = pathname === to
+              return (
               <Link
                 key={to}
                 component={isActive ? 'span' : RouterLink}
@@ -34,11 +35,12 @@ export default function LandingLayout() {
         <StatusBadge />
       </Box>
       <Box component="main">
-        <Outlet />
-      </Box>
-      <Typography component="footer" mt={6} fontSize={12} color="text.secondary">
-        © {new Date().getFullYear()} FORMA Urbana
-      </Typography>
-    </Container>
+          <Outlet />
+        </Box>
+        <Typography component="footer" mt={6} fontSize={12} color="text.secondary">
+          © {new Date().getFullYear()} FORMA Urbana
+        </Typography>
+      </Container>
+    </Box>
   )
 }

--- a/src/pages/landing/CinturonAcero.jsx
+++ b/src/pages/landing/CinturonAcero.jsx
@@ -25,12 +25,17 @@ export default function CinturonAcero() {
         title="FORMA Urbana — Cinturón de Acero | EMSCULPT NEO + Radiofrecuencia (Montevideo)"
         description="Definí y tensá abdomen en 60’: EMSCULPT NEO (HIFEM + RF) + RF de piel + Maderoterapia + Drenaje. Sesión $1.900. Cuponera 6 a $6.200 (Oferta de Apertura). Reservá por WhatsApp."
       />
-      <Box component="header" sx={{ textAlign: 'center', bgcolor: 'success.light', color: 'success.contrastText', py: { xs: 6, md: 8 } }}>
-        <Container>
-          <Box sx={{ width: 120, height: 120, mx: 'auto', mb: 3, bgcolor: 'grey.200', borderRadius: 2 }} />
-          <Typography variant="h1" sx={{ fontWeight: 'bold' }} gutterBottom>
-            Cinturón de Acero
-          </Typography>
+        <Box component="header" sx={{ textAlign: 'center', bgcolor: 'success.light', color: 'success.contrastText', py: { xs: 6, md: 8 } }}>
+          <Container>
+            <Box
+              component="img"
+              src="/landings/cinturon-acero/placeholder-hero.svg"
+              alt="Cinturón de Acero"
+              sx={{ width: '100%', maxWidth: 400, height: 'auto', mx: 'auto', mb: 3, borderRadius: 2 }}
+            />
+            <Typography variant="h1" sx={{ fontWeight: 'bold' }} gutterBottom>
+              Cinturón de Acero
+            </Typography>
           <Typography variant="h5" gutterBottom>
             Llevá tu abdomen a su <strong>máximo potencial</strong>.
           </Typography>
@@ -50,11 +55,17 @@ export default function CinturonAcero() {
           </Button>
         </Container>
       </Box>
-      <Container sx={{ py: 4 }}>
-        <Typography align="center" sx={{ fontStyle: 'italic' }}>
-          En <strong>Montevideo</strong>. <strong>Nivel avanzado</strong> (para quienes ya vienen cuidándose y quieren <strong>seguir tonificando músculo y piel</strong>). <strong>No invasivo. Sin agujas. Agenda activa.</strong>
-        </Typography>
-      </Container>
+        <Container sx={{ py: 4 }}>
+          <Typography align="center" sx={{ fontStyle: 'italic' }}>
+            En <strong>Montevideo</strong>. <strong>Nivel avanzado</strong> (para quienes ya vienen cuidándose y quieren <strong>seguir tonificando músculo y piel</strong>). <strong>No invasivo. Sin agujas. Agenda activa.</strong>
+          </Typography>
+          <Box
+            component="img"
+            src="/landings/cinturon-acero/placeholder-extra.svg"
+            alt="Resultados del Cinturón de Acero"
+            sx={{ width: '100%', maxWidth: 600, mx: 'auto', mt: 4, borderRadius: 2 }}
+          />
+        </Container>
       <Container component="section" sx={{ py: 4 }}>
         <Typography variant="h3" align="center" gutterBottom>
           ¿Por qué funciona (lo esencial y sin humo)?

--- a/src/pages/landing/CinturonOrion.jsx
+++ b/src/pages/landing/CinturonOrion.jsx
@@ -25,12 +25,17 @@ export default function CinturonOrion() {
         title="FORMA Urbana — Cinturón de Orión | Lipo Láser 635 nm + Maderoterapia + Drenaje (Montevideo)"
         description="Reducí el contorno abdominal sin cirugía. Protocolo 3‑en‑1: Lipo Láser 635 nm + Maderoterapia + Drenaje Linfático. Sesión $1.500. Cuponera 6 a $5.500 (Oferta de Apertura)."
       />
-      <Box component="header" sx={{ textAlign: 'center', bgcolor: 'success.light', color: 'success.contrastText', py: { xs: 6, md: 8 } }}>
-        <Container>
-          <Box sx={{ width: 120, height: 120, mx: 'auto', mb: 3, bgcolor: 'grey.200', borderRadius: 2 }} />
-          <Typography variant="h1" sx={{ fontWeight: 'bold' }} gutterBottom>
-            Cinturón de Orión
-          </Typography>
+        <Box component="header" sx={{ textAlign: 'center', bgcolor: 'success.light', color: 'success.contrastText', py: { xs: 6, md: 8 } }}>
+          <Container>
+            <Box
+              component="img"
+              src="/landings/cinturon-orion/placeholder-hero.svg"
+              alt="Cinturón de Orión"
+              sx={{ width: '100%', maxWidth: 400, height: 'auto', mx: 'auto', mb: 3, borderRadius: 2 }}
+            />
+            <Typography variant="h1" sx={{ fontWeight: 'bold' }} gutterBottom>
+              Cinturón de Orión
+            </Typography>
           <Typography variant="h5" gutterBottom>
             Cintura más definida, sin cirugía.
           </Typography>
@@ -50,11 +55,17 @@ export default function CinturonOrion() {
           </Button>
         </Container>
       </Box>
-      <Container sx={{ py: 4 }}>
-        <Typography align="center" sx={{ fontStyle: 'italic' }}>
-          En Montevideo. No invasivo. Sin agujas. Piel intacta. Apto como <strong>nivel inicial</strong> para personas poco activas físicamente.
-        </Typography>
-      </Container>
+        <Container sx={{ py: 4 }}>
+          <Typography align="center" sx={{ fontStyle: 'italic' }}>
+            En Montevideo. No invasivo. Sin agujas. Piel intacta. Apto como <strong>nivel inicial</strong> para personas poco activas físicamente.
+          </Typography>
+          <Box
+            component="img"
+            src="/landings/cinturon-orion/placeholder-extra.svg"
+            alt="Resultados del Cinturón de Orión"
+            sx={{ width: '100%', maxWidth: 600, mx: 'auto', mt: 4, borderRadius: 2 }}
+          />
+        </Container>
       <Container component="section" sx={{ py: 4 }}>
         <Typography variant="h3" align="center" gutterBottom>
           ¿Por qué el Cinturón de Orión funciona?

--- a/src/pages/landing/CinturonTitan.jsx
+++ b/src/pages/landing/CinturonTitan.jsx
@@ -25,12 +25,17 @@ export default function CinturonTitan() {
         title="FORMA Urbana — Cinturón de Titán | EMSCULPT NEO + Lipo Láser (Montevideo)"
         description="Definí y reducí abdomen en la misma sesión: EMSCULPT NEO (HIFEM + RF) + Lipo Láser 635 nm + Maderoterapia + Pulido. Sesión $2.000. Cuponera 6 a $6.600 (Oferta de Apertura). Reservá por WhatsApp."
       />
-      <Box component="header" sx={{ textAlign: 'center', bgcolor: 'success.light', color: 'success.contrastText', py: { xs: 6, md: 8 } }}>
-        <Container>
-          <Box sx={{ width: 120, height: 120, mx: 'auto', mb: 3, bgcolor: 'grey.200', borderRadius: 2 }} />
-          <Typography variant="h1" sx={{ fontWeight: 'bold' }} gutterBottom>
-            Cinturón de Titán
-          </Typography>
+        <Box component="header" sx={{ textAlign: 'center', bgcolor: 'success.light', color: 'success.contrastText', py: { xs: 6, md: 8 } }}>
+          <Container>
+            <Box
+              component="img"
+              src="/landings/cinturon-titan/placeholder-hero.svg"
+              alt="Cinturón de Titán"
+              sx={{ width: '100%', maxWidth: 400, height: 'auto', mx: 'auto', mb: 3, borderRadius: 2 }}
+            />
+            <Typography variant="h1" sx={{ fontWeight: 'bold' }} gutterBottom>
+              Cinturón de Titán
+            </Typography>
           <Typography variant="h5" gutterBottom>
             Reduce <strong>y</strong> tonifica en la misma sesión.
           </Typography>
@@ -54,11 +59,17 @@ export default function CinturonTitan() {
           </Button>
         </Container>
       </Box>
-      <Container sx={{ py: 4 }}>
-        <Typography align="center" sx={{ fontStyle: 'italic' }}>
-          En <strong>Montevideo</strong>. <strong>Nivel intermedio</strong> (ideal para quienes ya vienen cuidándose y quieren <strong>rematar la grasa rebelde</strong> del abdomen). <strong>Sin agujas, sin quirófano.</strong>
-        </Typography>
-      </Container>
+        <Container sx={{ py: 4 }}>
+          <Typography align="center" sx={{ fontStyle: 'italic' }}>
+            En <strong>Montevideo</strong>. <strong>Nivel intermedio</strong> (ideal para quienes ya vienen cuidándose y quieren <strong>rematar la grasa rebelde</strong> del abdomen). <strong>Sin agujas, sin quirófano.</strong>
+          </Typography>
+          <Box
+            component="img"
+            src="/landings/cinturon-titan/placeholder-extra.svg"
+            alt="Resultados del Cinturón de Titán"
+            sx={{ width: '100%', maxWidth: 600, mx: 'auto', mt: 4, borderRadius: 2 }}
+          />
+        </Container>
       <Container component="section" sx={{ py: 4 }}>
         <Typography variant="h3" align="center" gutterBottom>
           ¿Por qué el Cinturón de Titán funciona?


### PR DESCRIPTION
## Summary
- agrega fondo gris a LandingLayout
- incorpora imágenes de placeholder en Cinturón de Orión, Titán y Acero
- añade archivos SVG de placeholder para futuras imágenes

## Testing
- `npm test` (falla: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a67e0ca7708326953c212854a1eac5