### PR TITLE
Exempt campaign products from the 24-hour booking restriction

### DIFF
--- a/src/components/DateTimeSlotPicker.jsx
+++ b/src/components/DateTimeSlotPicker.jsx
@@ -13,6 +13,7 @@ import {
   isCampaignTreatment,
   fetchAllCampaignSlots,
   filterSlotsForCustomer,
+  filterSlotsForCampaign,
 } from "../utils/slotUtils";
 
 dayjs.extend(utc);
@@ -85,14 +86,15 @@ export default function DateTimeSlotPicker({
       ? 30
       : treatment.duration_minutes || SESSION_DURATION;
   const memoizedFilterSlots = useCallback(
-    filterSlotsProp || filterSlotsForCustomer,
-    [filterSlotsProp],
+    filterSlotsProp || (isCampaign ? filterSlotsForCampaign : filterSlotsForCustomer),
+    [filterSlotsProp, isCampaign],
   );
 
   const days = useMemo(() => {
     const list = [];
     const today = dayjs().tz("America/Montevideo").startOf("day");
-    for (let i = 1; i <= 21; i += 1) {
+    const startOffset = isCampaign ? 0 : 1;
+    for (let i = startOffset; i <= 21; i += 1) {
       const d = today.add(i, "day");
       list.push({
         key: d.format("YYYY-MM-DD"),
@@ -103,7 +105,7 @@ export default function DateTimeSlotPicker({
       });
     }
     return list;
-  }, []);
+  }, [isCampaign]);
 
   const campaignDates = useMemo(() => {
     if (!isCampaign || allCampaignSlots.length === 0) return new Set();

--- a/src/pages/user/ExistingAppointmentPage.jsx
+++ b/src/pages/user/ExistingAppointmentPage.jsx
@@ -17,7 +17,7 @@ import SlideToConfirm from "../../components/common/SlideToConfirm";
 import {useNavigate, useLocation, Navigate} from "react-router-dom";
 import {useAuth} from "../../contexts/AuthContext";
 import {useBusiness} from "../../contexts/BusinessContext";
-import {filterSlotsForCustomer} from "../../utils/slotUtils";
+import {isCampaignTreatment, filterSlotsForCampaign} from "../../utils/slotUtils";
 import {LocalizationProvider} from "@mui/x-date-pickers";
 import {AdapterDayjs} from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
@@ -160,10 +160,13 @@ export default function ExistingAppointmentPage() {
   const rescheduleTreatment = useMemo(() => treatmentFromAppointment(appointmentData), [appointmentData]);
   const rescheduleFilterSlots = useCallback(
     (isoSlots) => {
+      if (isCampaignTreatment(rescheduleTreatment)) {
+        return filterSlotsForCampaign(isoSlots);
+      }
       const cutoff = dayjs().tz("America/Montevideo").add(appointmentData?.status === "confirmed" ? 48 : 24, "hour");
       return isoSlots.filter(s => dayjs.utc(s).tz("America/Montevideo").isAfter(cutoff));
     },
-    [appointmentData?.status],
+    [appointmentData?.status, rescheduleTreatment],
   );
 
   const scheduleFilterSlots = useCallback((isoSlots) => {

--- a/src/utils/slotUtils.js
+++ b/src/utils/slotUtils.js
@@ -55,6 +55,17 @@ export function filterSlotsForCustomer(slots) {
 }
 
 /**
+ * Filter slots for campaign products — only drop past slots, no 24h advance window
+ * Input: raw ISO datetime strings
+ */
+export function filterSlotsForCampaign(slots) {
+  const now = dayjs().tz('America/Montevideo');
+  return slots.filter(slot =>
+    dayjs.utc(slot).tz('America/Montevideo').isAfter(now)
+  );
+}
+
+/**
  * Resolve appointment duration based on treatment and payment mode
  */
 export function getSlotDuration(treatment, paymentMode) {


### PR DESCRIPTION
Campaign products (treatments with an item_type) should be bookable
today and within the next 24 hours. The frontend re-applied the 24h
advance-booking filter client-side and never showed the current day,
which undid the backend exemption.

- Add filterSlotsForCampaign: drops only past slots, no 24h window
- DateTimeSlotPicker: use the campaign filter and include today in the
  date strip for campaign treatments
- ExistingAppointmentPage: bypass the 24h/48h reschedule cutoff when
  rescheduling a campaign appointment

https://claude.ai/code/session_013QJDVDbNkf2ZYmGRY7L7A9